### PR TITLE
Added tests, then added fixes for those tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,29 +9,25 @@
 'use strict';
 
 function formatMoney( num, opts ) {
-  var decPlaces = 0, // decPlaces, taken from opts
-      sign = '', // sign, either '' or '-'
-      numericValue = Math.abs( num ), // Absolute numeric value of num
-      wholePart = 0, // whole number part of num
-      formattedString = ''; // final formatted String to be returned
-
-  opts = opts || {};
+  var decPlaces = 0,
+      sign = '',
+      numericValue = num,
+      stringValue = '',
+      formattedString = '',
+      handleStringInput = require('./lib/handle-string-input.js'),
+      commaSeparate = require('./lib/comma-separate-number.js');
 
   // Handle a String as input
   if ( typeof num === 'string' ) {
-    // If a '-' appears before the first digit, we assume num is negative
-    var minusPos = num.indexOf( num.match( '-' ) ),
-        digitPos = num.indexOf( num.match( /\d/ ) );
-    if ( num.indexOf( num.match( '-' ) ) !== -1 && minusPos < digitPos ) {
-      sign = '-';
-    }
+    numericValue = handleStringInput( num );
+  }
 
-    // Strip numeric values, then convert to a number (while maintaining sign)
-    numericValue = Number( num.replace( /[^0-9\.]+/g, '' ) );
-  } else if ( num < 0 ) {
-  // If num is a negative number, assign sign
+  // Determine sign
+  if ( numericValue < 0 ) {
     sign = '-';
   }
+
+  opts = opts || {};
 
   // Determine decimal places
   decPlaces = Math.abs( opts.decimalPlaces );
@@ -39,22 +35,16 @@ function formatMoney( num, opts ) {
     decPlaces = 2;
   }
 
-  // Get the offset of comma separation
-  wholePart = Math.floor( Number( numericValue ) );
+  // Get absolute value, apply decimal places limit, return string
+  stringValue = Math.abs( numericValue ).toFixed( decPlaces );
+
+  // Get a comma-separated string of the absolute value of numericValue
+  stringValue = commaSeparate( stringValue );
 
   // Construct the formattedString
-  formattedString = sign + '$';
-
-  // add commas to numericValue
-  formattedString += wholePart.toString().replace( /(\d)(?=(\d{3})+(?!\d))/g, '$1,' );
-
-  // add decimal places
-  if ( decPlaces !== 0 ) {
-    formattedString += '.' + Math.abs( numericValue - wholePart ).toFixed( decPlaces ).slice( 2 );
-  }
+  formattedString = sign + '$' + stringValue;
 
   return formattedString;
-
 }
 
 module.exports = formatMoney;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@
  * @returns {string}      The number in USD format.
  */
 
+'use strict';
+
 function formatMoney( num, opts ) {
   var decPlaces = 0, // decPlaces, taken from opts
       sign = '', // sign, either '' or '-'
@@ -13,9 +15,7 @@ function formatMoney( num, opts ) {
       wholePart = 0, // whole number part of num
       formattedString = ''; // final formatted String to be returned
 
-  if ( typeof opts === 'undefined' ) {
-    opts = {};
-  }
+  opts = opts || {};
 
   // Handle a String as input
   if ( typeof num === 'string' ) {
@@ -34,11 +34,9 @@ function formatMoney( num, opts ) {
   }
 
   // Determine decimal places
-  opts.decimalPlaces = Math.abs( opts.decimalPlaces );
-  if ( isNaN( opts.decimalPlaces ) ) {
+  decPlaces = Math.abs( opts.decimalPlaces );
+  if ( isNaN( decPlaces ) ) {
     decPlaces = 2;
-  } else {
-    decPlaces = opts.decimalPlaces;
   }
 
   // Get the offset of comma separation

--- a/index.js
+++ b/index.js
@@ -1,26 +1,62 @@
 /**
  * @param  {string|number} num  A number or a string in a numbery format
- * @param  {object} opts Optionally specify the number of decimal places 
+ * @param  {object} opts Optionally specify the number of decimal places
  *   you'd like in the returned string with the `decimalPlaces` key.
  *   e.g. {decimalPlaces: 0}
- * @return {string}      The number in USD format.
+ * @returns {string}      The number in USD format.
  */
-var formatMoney = function( num, opts ) {
 
-  opts = opts || {};
-  if (typeof num === 'string') num =  Number(num.replace(/[^0-9\.]+/g,""));
+function formatMoney( num, opts ) {
+  var decPlaces = 0, // decPlaces, taken from opts
+      sign = '', // sign, either '' or '-'
+      numericValue = Math.abs( num ), // Absolute numeric value of num
+      wholePart = 0, // whole number part of num
+      formattedString = ''; // final formatted String to be returned
 
-  var decPlaces = isNaN( opts.decimalPlaces = Math.abs(opts.decimalPlaces) ) ? 2 : opts.decimalPlaces,
-      sign = num < 0 ? '-' : '',
-      i = parseInt( num = Math.abs(+num || 0).toFixed(decPlaces), 10 ) + '',
-      j = ( j = i.length ) > 3 ? j % 3 : 0;
+  if ( typeof opts === 'undefined' ) {
+    opts = {};
+  }
 
-  return sign + 
-        '$' + 
-        ( j ? i.substr(0, j) + ',' : '' ) + 
-        i.substr( j ).replace( /(\d{3})(?=\d)/g, '$1,' ) + 
-        ( decPlaces ? '.' + Math.abs(num - i).toFixed(decPlaces).slice(2) : '');
+  // Handle a String as input
+  if ( typeof num === 'string' ) {
+    // If a '-' appears before the first digit, we assume num is negative
+    var minusPos = num.indexOf( num.match( '-' ) ),
+        digitPos = num.indexOf( num.match( /\d/ ) );
+    if ( num.indexOf( num.match( '-' ) ) !== -1 && minusPos < digitPos ) {
+      sign = '-';
+    }
 
-};
+    // Strip numeric values, then convert to a number (while maintaining sign)
+    numericValue = Number( num.replace( /[^0-9\.]+/g, '' ) );
+  } else if ( num < 0 ) {
+  // If num is a negative number, assign sign
+    sign = '-';
+  }
+
+  // Determine decimal places
+  opts.decimalPlaces = Math.abs( opts.decimalPlaces );
+  if ( isNaN( opts.decimalPlaces ) ) {
+    decPlaces = 2;
+  } else {
+    decPlaces = opts.decimalPlaces;
+  }
+
+  // Get the offset of comma separation
+  wholePart = Math.floor( Number( numericValue ) );
+
+  // Construct the formattedString
+  formattedString = sign + '$';
+
+  // add commas to numericValue
+  formattedString += wholePart.toString().replace( /(\d)(?=(\d{3})+(?!\d))/g, '$1,' );
+
+  // add decimal places
+  if ( decPlaces !== 0 ) {
+    formattedString += '.' + Math.abs( numericValue - wholePart ).toFixed( decPlaces ).slice( 2 );
+  }
+
+  return formattedString;
+
+}
 
 module.exports = formatMoney;

--- a/lib/comma-separate-number.js
+++ b/lib/comma-separate-number.js
@@ -1,0 +1,23 @@
+/**
+ * @param  {string} numberString  A string representing a number
+ * @returns {string} The number in a comma-separated format.
+ */
+
+'use strict';
+
+function commaSeparate( numberString ) {
+
+  var string = numberString.toString(),
+      // split string of number by the decimal point
+      parts = string.split( '.' ),
+      // format the whole number part of the string with a regex
+      formattedValue = parts[0].replace( /(\d)(?=(\d{3})+(?!\d))/g, '$1,' );
+  // Add back decimal part if it exists
+  if ( typeof parts[1] !== 'undefined' ) {
+    formattedValue += '.' + parts[1];
+  }
+
+  return formattedValue;
+}
+
+module.exports = commaSeparate;

--- a/lib/handle-string-input.js
+++ b/lib/handle-string-input.js
@@ -1,0 +1,38 @@
+/**
+ * Turns a string into a number.
+ * Assumes each number in the string should be preserved (unlike parseInt)
+ * Assumes the first instance of a decimal point is the intended one
+ * @param  {string} numberString  A string representing a number
+ * @returns {number} The assumed numeric value of numberString
+ */
+
+'use strict';
+
+function handleStringInput( numberString ) {
+  var signMaker = 1,
+      minusPosition = numberString.indexOf( numberString.match( '-' ) ),
+      digitPosition = numberString.indexOf( numberString.match( /\d/ ) );
+
+  // If a '-' appears before the first digit, we assume numberString is negative
+  if ( numberString.indexOf( numberString.match( '-' ) ) !== -1 && minusPosition < digitPosition ) {
+    signMaker = -1;
+  }
+
+  // Strip non-numeric values, maintaining periods
+  numberString = numberString.replace( /[^0-9\.]+/g, '' );
+
+  // Strip any periods after the first
+  function replaceCommas( match, offset, full ) {
+    if ( offset === full.indexOf( '.' ) ) {
+      return '.';
+    }
+    return '';
+  }
+  numberString.replace( /\./g, replaceCommas );
+
+  // Get number value of string, then multiply by signMaker and return
+  return Number( numberString ) * signMaker;
+
+}
+
+module.exports = handleStringInput;

--- a/lib/handle-string-input.js
+++ b/lib/handle-string-input.js
@@ -28,7 +28,7 @@ function handleStringInput( numberString ) {
     }
     return '';
   }
-  numberString.replace( /\./g, replaceCommas );
+  numberString = numberString.replace( /\./g, replaceCommas );
 
   // Get number value of string, then multiply by signMaker and return
   return Number( numberString ) * signMaker;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-usd",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index.js",
   "description": "Convert a number to a USD-formatted string",
   "homepage": "https://github.com/cfpb/format-usd",

--- a/test/format-usd-tests.js
+++ b/test/format-usd-tests.js
@@ -1,4 +1,6 @@
-var formatUSD = require('../index.js');
+var formatUSD = require('../index.js'),
+    commaSeparate = require('../lib/comma-separate-number.js'),
+    handleStringInput = require('../lib/handle-string-input.js');
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -81,6 +83,55 @@ exports.formatUSD = {
     test.equal( formatUSD(-99, {decimalPlaces: 0}), '-$99' );
     test.equal( formatUSD(-1234, {decimalPlaces: 0}), '-$1,234' );
     test.equal( formatUSD(-5.55, {decimalPlaces: 2}), '-$5.55' );
+    test.done();
+  }
+};
+
+exports.handleStringInput = {
+  setUp: function(done) {
+    // setup here
+    done();
+  },
+  'Parse number strings with non-numeric characters': function(test) {
+    test.expect(6);
+    // tests here
+    test.equal( handleStringInput( '9a99' ), 999 );
+    test.equal( handleStringInput( 'u123456' ), 123456 );
+    test.equal( handleStringInput( '01234' ), 1234 );
+    test.equal( handleStringInput( '$1,234,567' ), 1234567 );
+    test.equal( handleStringInput( 'Ilikethenumber5' ), 5 );
+    test.equal( handleStringInput( 'function somefunction() { do badstuff; }' ), 0 );
+    test.done();
+  },
+  'Parse the first period as a decimal point': function(test) {
+    test.expect(3);
+    // tests here
+    test.equal( handleStringInput( '4.22' ), 4.22 );
+    test.equal( handleStringInput( 'I.like.the.number.5' ), 0.5 );
+    test.equal( handleStringInput( '1.2.3.4.5.6.7' ), 1.234567 );
+    test.done();
+  }
+};
+
+exports.commaSeparate = {
+  setUp: function(done) {
+    // setup here
+    done();
+  },
+  'Comma separte a numeric string': function(test) {
+    test.expect(4);
+    // tests here
+    test.equal( commaSeparate( '1234567' ), '1,234,567' );
+    test.equal( commaSeparate( '1234' ), '1,234' );
+    test.equal( commaSeparate( '5' ), '5' );
+    test.equal( commaSeparate( '199' ), '199' );
+    test.done();
+  },
+  'Handle numeric strings with >3 decimal places': function(test) {
+    test.expect(2);
+    // tests here
+    test.equal( commaSeparate( '9.1234' ), '9.1234' );
+    test.equal( commaSeparate( '12345678.999999' ), '12,345,678.999999' );
     test.done();
   }
 };

--- a/test/format-usd-tests.js
+++ b/test/format-usd-tests.js
@@ -72,8 +72,15 @@ exports.formatUSD = {
   'Format strings by removing non-numeric characters': function(test) {
     test.expect(3);
     test.equal( formatUSD("foo99", {decimalPlaces: 0}), '$99' );
-    test.equal( formatUSD("--??!!1,2,3,4,5,6,7", {decimalPlaces: 0}), '$1,234,567' );
+    test.equal( formatUSD("--??!!1,2,3,4,5,6,7", {decimalPlaces: 0}), '-$1,234,567' );
     test.equal( formatUSD("zero", {decimalPlaces: 0}), '$0' );
+    test.done();
+  },
+  'Preserve negative numbers as negative dollars': function(test) {
+    test.expect(3);
+    test.equal( formatUSD(-99, {decimalPlaces: 0}), '-$99' );
+    test.equal( formatUSD(-1234, {decimalPlaces: 0}), '-$1,234' );
+    test.equal( formatUSD(-5.55, {decimalPlaces: 2}), '-$5.55' );
     test.done();
   }
 };

--- a/test/format-usd-tests.js
+++ b/test/format-usd-tests.js
@@ -118,7 +118,7 @@ exports.commaSeparate = {
     // setup here
     done();
   },
-  'Comma separte a numeric string': function(test) {
+  'Comma separate a numeric string': function(test) {
     test.expect(4);
     // tests here
     test.equal( commaSeparate( '1234567' ), '1,234,567' );


### PR DESCRIPTION
This PR updates format-usd to 0.2.0. No functionality has changed, but there are several fixes.

Basically, while looking over this module for use in my next project, I realized the tests weren't covering negative dollar values, and that the code probably wasn't handling them correctly. I added tests for negatives, and I was right, so I fixed the code to handle negatives.

While I was doing that, I also overhauled the code for verbosity and made it much closer to our [front-end standards](https://github.com/cfpb/front-end). At @ascott1's suggestion, I moved some functionality into separate `./lib` files (and added tests for those functions). Then I fixed the code so that it could handle strings with multiple periods (by assuming the first period is the intended decimal place).

## Additions
- Extra code and comments to make the code clearer and more verbose

## Changes
- Variable names, to make them clearer
- Some functionality separate into functions and placed in `./lib/[some-function].js`

## Testing
- Tests added for negative numbers
- Tests added for `comma-separate-number.js` and `handle-string-input.js`

## Review
- @contolini @ascott1 and anyone else who's interested!

## Checklist
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Thanks
Thanks to @ascott1 for reviewing the commits and giving feedback!

## Animated GIF
Me when I remove ternary operators:
![celebrate!](http://media.giphy.com/media/pBevuxpD4Tq4U/giphy.gif)